### PR TITLE
Include dovecot recipe only once with auth_sql

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -3,6 +3,10 @@ provisioner:
   data_bags_path: test/integration/data_bags
   encrypted_data_bag_secret_key_path: test/integration/encrypted_data_bag_secret
   attributes:
+    osl-imap:
+      auth_sql:
+        data_bag: 'sql_creds'
+        data_bag_item: 'mysql'
     percona:
       encrypted_data_bag: percona
       encrypted_data_bag_secret_file: "/etc/chef/encrypted_data_bag_secret"
@@ -29,8 +33,6 @@ suites:
         auth_sql:
           enable_userdb: true
           enable_passdb: true
-          data_bag: 'sql_creds'
-          data_bag_item: 'mysql'
     driver:
       flavor_ref: 'm1.medium'
   - name: lmtp

--- a/Berksfile
+++ b/Berksfile
@@ -1,6 +1,7 @@
 source 'https://supermarket.chef.io'
 solver :ruby, :required
 
+cookbook 'apache2', '< 6.0.0'
 cookbook 'base', git: 'git@github.com:osuosl-cookbooks/base'
 cookbook 'dovecot', git: 'git@github.com:osuosl-cookbooks/dovecot-cookbook'
 cookbook 'firewall', git: 'git@github.com:osuosl-cookbooks/firewall'

--- a/recipes/auth_sql.rb
+++ b/recipes/auth_sql.rb
@@ -38,23 +38,3 @@ else
   raise "osl-imap::auth_sql currently only supports database drivers 'mysql' & 'pgsql' in
 node['dovecot']['conf']['sql']['driver']. Fix the databag or update the recipe."
 end
-
-include_recipe 'dovecot::default' # Must include here for edit_resource
-
-edit_resource(:template, '(core) dovecot-sql.conf.ext') do
-  cookbook 'osl-imap'
-  variables(auth: node['dovecot']['auth'].to_hash,
-            protocols: node['dovecot']['protocols'].to_hash,
-            services: node['dovecot']['services'].to_hash,
-            plugins: node['dovecot']['plugins'].to_hash,
-            namespaces: node['dovecot']['namespaces'],
-            conf: node['dovecot']['conf'],
-            # We edited @connect into the template to avoid putting secrets in attributes
-            connect: %W(
-              host=#{creds['host']}
-              dbname=#{creds['db']}
-              user=#{creds['user']}
-              password=#{creds['pass']}
-            ),
-            sensitive: true)
-end

--- a/spec/unit/recipes/auth_sql_spec.rb
+++ b/spec/unit/recipes/auth_sql_spec.rb
@@ -11,12 +11,6 @@ describe 'osl-imap::auth_sql' do
       it 'converges successfully' do
         expect { chef_run }.to_not raise_error
       end
-      it do
-        expect(chef_run).to include_recipe 'dovecot::default'
-      end
-      it do
-        expect(chef_run).to create_template '(core) dovecot-sql.conf.ext'
-      end
       context "SQL databag's database type is not 'mysql' or 'pgsql'" do
         before do
           stub_data_bag_item(nil, nil).and_return(

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -29,6 +29,9 @@ describe 'osl-imap::default' do
           expect(chef_run).to_not include_recipe recipe
         end
       end
+      it do
+        expect(chef_run).to_not create_template '(core) dovecot-sql.conf.ext'
+      end
       context 'LMTP enabled' do
         cached(:chef_run) do
           ChefSpec::SoloRunner.new(p) do |node|
@@ -51,6 +54,9 @@ describe 'osl-imap::default' do
           end
           it do
             expect(chef_run).to include_recipe 'osl-imap::auth_sql'
+          end
+          it do
+            expect(chef_run).to create_template '(core) dovecot-sql.conf.ext'
           end
         end
       end


### PR DESCRIPTION
This fixes a bug where the dovecot config file would be rendered (with
default protocols) before the osl-imap::lmtp recipe was included,
meaning the LMTP protocol was erroneously disabled.

Moving the edit_resource for auth_sql into the default recipe prevents
the need to include dovecot twice.

----
If you'd like to reproduce the bug that this fixes, verify the `mail` suite in `proj-phpbb` [on this branch](https://github.com/osuosl-cookbooks/proj-phpbb/pull/242/commits/0b02774cdf0fdea6d679c65303fd1a282dd79314) (and double-check that the Berksfile is using osl-imap's master branch, without this fix.)