### PR TITLE
Allow default to handle undefined auth_sql databags

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -3,10 +3,6 @@ provisioner:
   data_bags_path: test/integration/data_bags
   encrypted_data_bag_secret_key_path: test/integration/encrypted_data_bag_secret
   attributes:
-    osl-imap:
-      auth_sql:
-        data_bag: 'sql_creds'
-        data_bag_item: 'mysql'
     percona:
       encrypted_data_bag: percona
       encrypted_data_bag_secret_file: "/etc/chef/encrypted_data_bag_secret"
@@ -33,6 +29,8 @@ suites:
         auth_sql:
           enable_userdb: true
           enable_passdb: true
+          data_bag: 'sql_creds'
+          data_bag_item: 'mysql'
     driver:
       flavor_ref: 'm1.medium'
   - name: lmtp


### PR DESCRIPTION
#3 introduced an issue where the attributes specifying the location of the SQL auth databag might be empty in `osl-imap::default` (like when it's included without the intent to actually use SQL auth). This fix just sets `creds` to an empty hash when SQL auth isn't enabled.