### PR TITLE
Chef 14 compatibility fixes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,11 +11,5 @@ Style/NumericLiteralPrefix:
 Metrics/LineLength:
   Max: 120
 
-Style/IfUnlessModifier:
-  MaxLineLength: 120
-
-Style/WhileUntilModifier:
-  MaxLineLength: 120
-
 Metrics/BlockLength:
   Enabled: false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,9 @@
 require 'chefspec'
 require 'chefspec/berkshelf'
 
-ChefSpec::Coverage.start! { add_filter 'osl-imap' }
-
 CENTOS_7 = {
   platform: 'centos',
-  version: '7.4.1708',
+  version: '7',
 }.freeze
 
 ALL_PLATFORMS = [
@@ -13,7 +11,7 @@ ALL_PLATFORMS = [
 ].freeze
 
 RSpec.configure do |config|
-  config.log_level = :fatal
+  config.log_level = :warn
 end
 
 shared_context 'dovecot_stubs' do


### PR DESCRIPTION
**Old ChefDK (before)**
- [x] Ensure all ChefSpec tests pass
- [x] Ensure all Inspec tests pass

**New ChefDK**
- [x] Ensure cookstyle is passing
- [x] Apply foodcritic fixes
- [x] Ensure `rake` passes
- [x] Ensure all Inspec tests pass

**Old ChefDK (after)**
- [x] Repeat all tests above using old ChefDK