### PR TITLE
Use safer SSL settings

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -2,7 +2,6 @@ source 'https://supermarket.chef.io'
 solver :ruby, :required
 
 cookbook 'dovecot', git: 'git@github.com:osuosl-cookbooks/dovecot-cookbook'
-cookbook 'firewall', git: 'git@github.com:osuosl-cookbooks/firewall'
 cookbook 'osl-firewall', git: 'git@github.com:osuosl-cookbooks/osl-firewall'
 
 # test dependencies

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -42,6 +42,18 @@ suites:
         pebble:
           host_aliases:
             - imap.osuosl.org
+    verifier:
+      inspec_tests:
+        - name: osuosl-baseline
+          git: https://github.com/osuosl/osuosl-baseline.git
+      controls:
+        - letsencrypt
+        - ssl-baseline
+      inputs:
+        ssl_port:
+          - 443
+          - 993
+          - 995
   - name: auth_sql
     run_list:
       - recipe[osl-imap-test::auth_sql]

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -38,6 +38,11 @@ end
 # Enable plaintext auth mechanisms as defaults, but disallow using them without TLS
 node.default['dovecot']['conf']['auth_mechanisms'] = %w(plain login)
 node.default['dovecot']['conf']['disable_plaintext_auth'] = true
+node.default['dovecot']['conf']['ssl_cipher_list'] = 'ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:!DES-CBC3-SHA:!DSS'
+node.default['dovecot']['conf']['ssl_dh_parameters_length'] = '2048'
+node.default['dovecot']['conf']['ssl_options'] = 'no_compression no_ticket'
+node.default['dovecot']['conf']['ssl_prefer_server_ciphers'] = 'yes'
+node.default['dovecot']['conf']['ssl_protocols'] = 'TLSv1.2'
 
 # Authentication socket for use with Postfix
 node.default['dovecot']['services']['auth']['listeners'] = [

--- a/test/integration/letsencrypt/inspec/letsencrypt_spec.rb
+++ b/test/integration/letsencrypt/inspec/letsencrypt_spec.rb
@@ -1,94 +1,95 @@
-describe service 'dovecot' do
-  it { should be_enabled }
-  it { should be_running }
-end
-
-%w(993 995).each do |p|
-  describe port p do
-    it { should be_listening }
+control 'letsencrypt' do
+  describe service 'dovecot' do
+    it { should be_enabled }
+    it { should be_running }
   end
-end
 
-%w(110 143).each do |num|
-  describe port num do
-    it { should_not be_listening }
+  %w(993 995).each do |p|
+    describe port p do
+      it { should be_listening }
+    end
   end
-end
 
-describe file '/etc/dovecot/conf.d/10-auth.conf' do
-  its('content') { should match(/disable_plaintext_auth = yes/) }
-  its('content') { should match(/auth_mechanisms = plain login/) }
-end
+  %w(110 143).each do |num|
+    describe port num do
+      it { should_not be_listening }
+    end
+  end
 
-describe file '/etc/dovecot/conf.d/10-master.conf' do
-  its('content') do
-    should match %r{service auth {
+  describe file '/etc/dovecot/conf.d/10-auth.conf' do
+    its('content') { should match(/disable_plaintext_auth = yes/) }
+    its('content') { should match(/auth_mechanisms = plain login/) }
+  end
+
+  describe file '/etc/dovecot/conf.d/10-master.conf' do
+    its('content') do
+      should match %r{service auth {
   unix_listener /var/spool/postfix/private/auth {
     group = postfix
     mode = 0660
     user = postfix
   }
 }}
+    end
   end
-end
 
-describe file '/var/spool/postfix/private/auth' do
-  it { should be_socket }
-  its('mode') { should cmp 0660 }
-  its('owner') { should eq 'postfix' }
-  its('group') { should eq 'postfix' }
-end
-
-describe file '/etc/dovecot/conf.d/10-ssl.conf' do
-  its('content') { should match(/ssl = required/) }
-  its('content') { should match %r{ssl_cert = </etc/pki/tls/imap.osuosl.org.crt} }
-  its('content') { should match %r{ssl_key = </etc/pki/tls/imap.osuosl.org.key} }
-end
-
-%w(
-  /etc/pki/tls/imap.osuosl.org.crt
-  /etc/pki/tls/imap.osuosl.org.key
-).each do |f|
-  describe file f do
-    it { should exist }
+  describe file '/var/spool/postfix/private/auth' do
+    it { should be_socket }
+    its('mode') { should cmp 0660 }
+    its('owner') { should eq 'postfix' }
+    its('group') { should eq 'postfix' }
   end
-end
-describe file '/etc/dovecot/dovecot.conf' do
-  its('content') { should match(/^protocols = imap pop3$/) }
-end
 
-describe file '/etc/dovecot/conf.d/10-auth.conf' do
-  # These pertain to system auth, which is enabled by default for this test suite
-  its('content') { should match /^auth_username_format = %n$/ }
-  its('content') { should match /^!include auth-system.conf.ext$/ }
-
-  # Other auths should be disabled by default
-  %w(checkpassword dict ldap passwdfile sql static vpopmail).each do |type|
-    its('content') { should match "^#!include auth-#{type}.conf.ext$" }
+  describe file '/etc/dovecot/conf.d/10-ssl.conf' do
+    its('content') { should match(/ssl = required/) }
+    its('content') { should match %r{ssl_cert = </etc/pki/tls/imap.osuosl.org.crt} }
+    its('content') { should match %r{ssl_key = </etc/pki/tls/imap.osuosl.org.key} }
   end
-end
 
-describe file '/etc/dovecot/conf.d/auth-system.conf.ext' do
-  its('content') do
-    should match(/passdb {
+  %w(
+    /etc/pki/tls/imap.osuosl.org.crt
+    /etc/pki/tls/imap.osuosl.org.key
+  ).each do |f|
+    describe file f do
+      it { should exist }
+    end
+  end
+  describe file '/etc/dovecot/dovecot.conf' do
+    its('content') { should match(/^protocols = imap pop3$/) }
+  end
+
+  describe file '/etc/dovecot/conf.d/10-auth.conf' do
+    # These pertain to system auth, which is enabled by default for this test suite
+    its('content') { should match /^auth_username_format = %n$/ }
+    its('content') { should match /^!include auth-system.conf.ext$/ }
+
+    # Other auths should be disabled by default
+    %w(checkpassword dict ldap passwdfile sql static vpopmail).each do |type|
+      its('content') { should match "^#!include auth-#{type}.conf.ext$" }
+    end
+  end
+
+  describe file '/etc/dovecot/conf.d/auth-system.conf.ext' do
+    its('content') do
+      should match(/passdb {
   driver = pam
   args = dovecot
 }/)
+    end
+    its('content') do
+      should match(/^userdb {.*driver = passwd.*}$/m)
+    end
   end
-  its('content') do
-    should match(/^userdb {.*driver = passwd.*}$/m)
+
+  describe command 'doveconf -S userdb passdb' do
+    its('stdout') { should match %r{^passdb/0/driver=pam$} }
+    its('stdout') { should match %r{^passdb/0/args=dovecot$} }
+    its('stdout') { should match %r{^userdb/0/driver=passwd$} }
+    its('exit_status') { should eq 0 }
   end
-end
 
-describe command 'doveconf -S userdb passdb' do
-  its('stdout') { should match %r{^passdb/0/driver=pam$} }
-  its('stdout') { should match %r{^passdb/0/args=dovecot$} }
-  its('stdout') { should match %r{^userdb/0/driver=passwd$} }
-  its('exit_status') { should eq 0 }
-end
-
-# Log in and fetch mail via IMAPS port
-describe command %(expect <<< '
+  # Log in and fetch mail via IMAPS port
+  describe command %(expect <<< '
 spawn openssl s_client -connect localhost:993
 expect {
   -re "OK .* Dovecot ready." {
@@ -106,6 +107,7 @@ expect {
     exit 1
   }
 }') do
-  its('exit_status') { should eq 0 }
-  its('stdout') { should match(/This test email should be fetchable via IMAP/) }
+    its('exit_status') { should eq 0 }
+    its('stdout') { should match(/This test email should be fetchable via IMAP/) }
+  end
 end


### PR DESCRIPTION
This ensures that we only use TLSv1.2 and only the ciphers that don't have any security issues.

Signed-off-by: Lance Albertson <lance@osuosl.org>
